### PR TITLE
Fix french translation of linelist (xlsx broken)

### DIFF
--- a/R/linelist_fr_translation.R
+++ b/R/linelist_fr_translation.R
@@ -127,6 +127,9 @@ sim_clean_fr <- sim_clean |>
 # save the fr clean version
 saveRDS(sim_clean_fr, here::here("data", "clean", "simulated_measles_ll_fr.rds"))
 
+
+
+
 ## Raw linelist ----------------------------
 
 # Load the raw linelist
@@ -201,8 +204,10 @@ sim_raw_final_fr <- sim_raw_final |>
     `Date de début des symptomes` = ymd(`Date de début des symptomes`)
   )
 # save the raw data
-saveRDS(sim_raw_final_fr, here::here("data", "final", "xlsx", "msf_listelineaire_rougeole_2023-09-24_fr.xlsx"))
-saveRDS(sim_raw_final_fr, here::here("data", "final", "csv", "msf_listelineaire_rougeole_2023-09-24_fr.csv"))
+export(sim_raw_final_fr, here::here("data", "final", "xlsx", "msf_listelineaire_rougeole_2023-09-24_fr.xlsx"))
+export(sim_raw_final_fr, here::here("data", "final", "csv", "msf_listelineaire_rougeole_2023-09-24_fr.csv"))
+
+
 
 # Translate lab data --------------------------------------------------------------
 
@@ -228,6 +233,7 @@ lab_clean_fr <- lab_clean |>
 
 # save clean lab result
 saveRDS(lab_clean_fr, here::here("data", "clean", "simulated_measles_lab_data_fr.rds"))
+
 
 ## Raw data ------------------------------------------------
 


### PR DESCRIPTION
Fix the export of the xlsx dirty translated linelist.

A `saveRDS()` was used instead of `rio::exports()`.